### PR TITLE
Use James source as default instead of James2019...for now.

### DIFF
--- a/R/calcGDPpppFuture.R
+++ b/R/calcGDPpppFuture.R
@@ -37,7 +37,7 @@ calcGDPpppFuture <- function(GDPpppFuture="SSP_completed") {
       data <- mbind(data,readSource(type="SRES",subtype=i))
     }
     getNames(data)<-paste0("gdp_",substr(getNames(data),6,7))
-    PPP_pc<-readSource(type="James2019",subtype ="IHME_USD05_PPP_pc")
+    PPP_pc<-readSource(type="James",subtype ="IHME_USD05_PPP_pc")
     pop<-readSource("WDI",subtype = "SP.POP.TOTL")
     years<-intersect(getYears(PPP_pc),getYears(pop))
     calib=PPP_pc[,years,]*pop[,years,]

--- a/R/calcGDPpppPast.R
+++ b/R/calcGDPpppPast.R
@@ -63,7 +63,7 @@ calcGDPpppPast <- function(GDPpppPast="IHME_USD05_PPP_pc_completed") {
     data<-PPP*colSums(inflator,na.rm=T)
     getNames(data) <- "GDPppp05_WDI_ICP11"
   } else if (type%in%c("IHME_USD05_PPP_pc","IHME_USD05_MER_pc","IMF_USD05_PPP_pc","PENN_USD05_PPP_pc","WB_USD05_PPP_pc","MADDISON_USD05_PPP_pc","WB_USD05_MER_pc","IMF_USD05_MER_pc","UN_USD05_MER_pc")) {
-    PPP_pc<-readSource(type="James2019",subtype = type)
+    PPP_pc<-readSource(type="James",subtype = type)
     pop<-readSource("WDI",subtype = "SP.POP.TOTL")
     years<-intersect(getYears(PPP_pc),getYears(pop))
     data=PPP_pc[,years,]*pop[,years,]

--- a/R/convertSRES.R
+++ b/R/convertSRES.R
@@ -41,7 +41,7 @@ convertSRES<-function(x,subtype){
    
   } else if (substring(subtype,nchar(subtype)-2)=="gdp"){
     
-    gdpJames<-readSource(type = "James2019",subtype="IHME_USD05_PPP_pc")
+    gdpJames<-readSource(type = "James",subtype="IHME_USD05_PPP_pc")
 	
     region_from<-"SCG"
     countries_to<-ISOhistorical$toISO[which(ISOhistorical$fromISO==region_from)]  


### PR DESCRIPTION
I'm replacing the James2019 calls with regular James calls.
This gives us more time to discuss the use of the new James data. 

Also, there was a bug in remind input preparation related to  `readSource(type="James2019",subtype = type)` in line 65 and 66 of `R/calcGDPPast.R`. Apparently, the James2019 csv doesn't have the exact same columns as the James csv. When/if reintroducing James2019, we will have to think of this!