### PR TITLE
Workaround for missing hdf5r on CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -75,3 +75,4 @@ Suggests:
     covr,
     Rilostat
 VignetteBuilder: knitr
+Remotes: hhoeflin/hdf5r


### PR DESCRIPTION
This is a (temporary) workaround that will allow your packages to build on macos: https://pik-piam.r-universe.dev/

When hdf5r is fixed on CRAN, we can remove the workaround: https://cran.r-project.org/web/packages/hdf5r/index.html