### PR TITLE
Read new emulator files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,6 @@ Imports:
     dplyr,
     hdf5r,
     GDPuc,
-    lazyeval,
     lpjclass,
     luscale,
     magpiesets (>= 0.44.2),

--- a/R/downloadISIMIP.R
+++ b/R/downloadISIMIP.R
@@ -41,7 +41,7 @@ downloadISIMIP <- function(subtype) {
     err <- try(suppressWarnings(download.file(paste0(storage,path),
                                               destfile = basename(path), mode = "wb",
                                               quiet = FALSE)), silent = TRUE)
-    if(class(err)=="try-error") stop("Data for requested subtype \"",subtype,"\" could not be found!")
+    if(inherits(err, "try-error")) stop("Data for requested subtype \"",subtype,"\" could not be found!")
   }
   .getMetadata <- function(dataset, version) {
     out <- list(doi = NULL, version = NULL, title = NULL, description = NULL)

--- a/R/readMAgPIE.R
+++ b/R/readMAgPIE.R
@@ -91,7 +91,13 @@ readMAgPIE <- function(subtype) {
                         "f30_bioen_price_SSP5-NDC-NDC_replaced_flat_",
                         "f30_bioen_price_SSP5-NDC-PkBudg1300_replaced_flat_",
                         "f30_bioen_price_SSP5-NDC-PkBudg900_replaced_flat_",
-                        "f30_bioen_price_SSP5-NPI-Base_replaced_flat_")
+                        "f30_bioen_price_SSP5-NPI-Base_replaced_flat_",
+                        "f30_bioen_price_SSP2-NDC-nocc-NDC_replaced_flat_",
+                        "f30_bioen_price_SSP2-NPI-nocc-Base_replaced_flat_",
+                        "f30_bioen_price_SSP2-NPI-nocc-NPI_replaced_flat_",
+                        "f30_bioen_price_SSP2-NDC-nocc-PkBudg500_replaced_flat_",
+                        "f30_bioen_price_SSP2-NDC-nocc-PkBudg1150_replaced_flat_"
+                        )
 
 
     fileList <- paste0(scenarioNames, regcode, ".cs4r")


### PR DESCRIPTION
This PR adds new emulator files to be read by `readMAgPIE`. These new emulators where calibrated with MAgPIE v4.4.0 for SSP2EU only. They substantially improve the convergence speed of coupled REMIND-MAgPIE runs.

The new files currently do not overlap with the old ones (which are needed for other SSPs) because their scenarios have `-nocc-` in the name, reflecting the new configuration in MAgPIE that turns climate change impacts off (they are on by default in this version). 

A sister PR in `mrremind` deals with the new names, using them as default for SSP2. But without those changes, this shouldn't affect the behavior of functions that use `readMAgPIE` because they just add more scenarios, not removing any.

The calibration runs for the new emulators can be found here `/p/projects/htc/MagpieEmulator/magpie440_2022-04-08` , with the flat fit replacement scripts and diagnostic plots for each scenario in `output/emulator`. 