### PR TITLE
Update source and mapping references for 2016 IEA Energy Balances

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '22016952'
+ValidationKey: '22037311'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrcommons: MadRat commons Input Data Library",
-  "version": "1.14.6",
+  "version": "1.14.7",
   "description": "<p>Provides useful functions and a common structure to all the input data required to run models like MAgPIE\n    and REMIND of model input data.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mrcommons
 Type: Package
 Title: MadRat commons Input Data Library
-Version: 1.14.6
-Date: 2022-08-08
+Version: 1.14.7
+Date: 2022-08-09
 Authors@R: c(person("Benjamin Leon", "Bodirsky", email = "bodirsky@pik-potsdam.de", role = "aut"),
              person("Kristine", "Karstens", role = "aut"),
              person("Lavinia", "Baumstark", role = "aut"),

--- a/R/convertIEA.R
+++ b/R/convertIEA.R
@@ -32,7 +32,7 @@ convertIEA <- function(x, subtype) {
     w <- wp + wg
 
     # disaggregating Other Africa (IAF), Other non-OECD Americas (ILA) and Other non-OECD Asia (IAS) regions to countries
-    mappingfile <- toolGetMapping(type = "regional", name = "regionmappingIEA.csv", returnPathOnly = TRUE)
+    mappingfile <- toolGetMapping(type = "regional", name = "regionmappingIEA_Other2016.csv", returnPathOnly = TRUE)
     mapping <- read.csv2(mappingfile, stringsAsFactors = TRUE)
     xadd <- toolAggregate(x[levels(mapping[[2]]), , ], mappingfile, weight = w[as.vector(mapping[[1]]), , ])
     x <- x[setdiff(getItems(x, dim = 1), as.vector(unique(mapping[[2]]))), , ]

--- a/R/readIEA.R
+++ b/R/readIEA.R
@@ -18,7 +18,7 @@
 readIEA <- function(subtype) {
   if (subtype == "EnergyBalances") { # IEA energy balances until 2015 (estimated 2016) (data updated in February, 2018)
     energyBalancesFile <- tempfile(fileext = "csv")
-    decompressFile("ExtendedEnergyBalances.csv.gz", energyBalancesFile, remove = FALSE, ext = "not_used", FUN = gzfile)
+    decompressFile("IEA-Energy-Balances-2016/ExtendedEnergyBalances.csv.gz", energyBalancesFile, remove = FALSE, ext = "not_used", FUN = gzfile)
     data <- fread(file = energyBalancesFile,
                   col.names = c("COUNTRY", "PRODUCT", "FLOW", "TIME", "ktoe"),
                   colClasses = c("character", "character", "character", "numeric", "character"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat commons Input Data Library
 
-R package **mrcommons**, version **1.14.6**
+R package **mrcommons**, version **1.14.7**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrcommons)](https://cran.r-project.org/package=mrcommons) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3822009.svg)](https://doi.org/10.5281/zenodo.3822009) [![R build status](https://github.com/pik-piam/mrcommons/workflows/check/badge.svg)](https://github.com/pik-piam/mrcommons/actions) [![codecov](https://codecov.io/gh/pik-piam/mrcommons/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrcommons) [![r-universe](https://pik-piam.r-universe.dev/badges/mrcommons)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **mrcommons** in publications use:
 
-Bodirsky B, Karstens K, Baumstark L, Weindl I, Wang X, Mishra A, Wirth S, Stevanovic M, Steinmetz N, Kreidenweis U, Rodrigues R, Popov R, Humpenoeder F, Giannousakis A, Levesque A, Klein D, Araujo E, Beier F, Oeser J, Pehl M, Leip D, Crawford M, Molina Bacca E, von Jeetze P, Martinelli E, Schreyer F, Soergel B, Führlich P, Hötten D, Hasse R, Dietrich J (2022). _mrcommons: MadRat commons Input Data Library_. doi: 10.5281/zenodo.3822009 (URL: https://doi.org/10.5281/zenodo.3822009), R package version 1.14.6, <URL: https://github.com/pik-piam/mrcommons>.
+Bodirsky B, Karstens K, Baumstark L, Weindl I, Wang X, Mishra A, Wirth S, Stevanovic M, Steinmetz N, Kreidenweis U, Rodrigues R, Popov R, Humpenoeder F, Giannousakis A, Levesque A, Klein D, Araujo E, Beier F, Oeser J, Pehl M, Leip D, Crawford M, Molina Bacca E, von Jeetze P, Martinelli E, Schreyer F, Soergel B, Führlich P, Hötten D, Hasse R, Dietrich J (2022). _mrcommons: MadRat commons Input Data Library_. doi:10.5281/zenodo.3822009 <https://doi.org/10.5281/zenodo.3822009>, R package version 1.14.7, <https://github.com/pik-piam/mrcommons>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrcommons: MadRat commons Input Data Library},
   author = {Benjamin Leon Bodirsky and Kristine Karstens and Lavinia Baumstark and Isabelle Weindl and Xiaoxi Wang and Abhijeet Mishra and Stephen Wirth and Mishko Stevanovic and Nele Steinmetz and Ulrich Kreidenweis and Renato Rodrigues and Roman Popov and Florian Humpenoeder and Anastasis Giannousakis and Antoine Levesque and David Klein and Ewerton Araujo and Felicitas Beier and Julian Oeser and Michaja Pehl and Debbora Leip and Michael Crawford and Edna {Molina Bacca} and Patrick {von Jeetze} and Eleonora Martinelli and Felix Schreyer and Bjoern Soergel and Pascal Führlich and David Hötten and Robin Hasse and Jan Philipp Dietrich},
   year = {2022},
-  note = {R package version 1.14.6},
+  note = {R package version 1.14.7},
   doi = {10.5281/zenodo.3822009},
   url = {https://github.com/pik-piam/mrcommons},
 }


### PR DESCRIPTION
This is a commit to prepare the upcoming switch to newer IEA data. It references the 2016-specific sources and region mapping explicitly so you can later switch back to using this instead of 2022 IEA data.

In particular, the plan is to
- move the source data to a subfolder IEA/IEA-Energy-Balances-2016
- rename the used region mapping "regionmappingIEA" to "regionmappingIEA_Other2016"

Once this has been merged I move and rename the files on the cluster accordingly. 

The 2022 IEA data references will follow the same naming conventions.