### PR TITLE
buildLibrary()

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '242623876'
+ValidationKey: '242730891'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Bootstrap
         run: |
@@ -57,10 +57,10 @@ jobs:
           cat /etc/R/Rprofile.site
 
       - name: Set up Pandoc
-        uses: r-lib/actions/setup-pandoc@v1
+        uses: r-lib/actions/setup-pandoc@v2
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrcommons: MadRat commons Input Data Library",
-  "version": "1.25.18",
+  "version": "1.25.19",
   "description": "<p>Provides useful functions and a common structure to all the input data required to run models like MAgPIE\n    and REMIND of model input data.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mrcommons
 Type: Package
 Title: MadRat commons Input Data Library
-Version: 1.25.18
-Date: 2023-01-25
+Version: 1.25.19
+Date: 2023-02-01
 Authors@R: c(person("Benjamin Leon", "Bodirsky", email = "bodirsky@pik-potsdam.de", role = "aut"),
              person("Kristine", "Karstens", role = "aut"),
              person("Lavinia", "Baumstark", role = "aut"),

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build check test lint format
+.PHONY: help build check test lint lint-all format format-all install docs
 .DEFAULT_GOAL = help
 
 # extracts the help text and formats it nicely
@@ -22,10 +22,18 @@ test:           ## Run testthat tests
 	Rscript -e 'devtools::test(show_report = TRUE)'
 
 lint:           ## Check if code etiquette is followed using lucode2::lint()
+                ## Only checks files you changed.
 	Rscript -e 'lucode2::lint()'
+
+lint-all:       ## Check if code etiquette is followed using lucode2::lint()
+                ## Checks all files.
+	Rscript -e 'lucode2::lint(".")'
 
 format:         ## Apply auto-formatting to changed files and lint afterwards
 	Rscript -e 'lucode2::autoFormat()'
+
+format-all:     ## Apply auto-formatting to all files and lint afterwards
+	Rscript -e 'lucode2::autoFormat(files=list.files("./R", full.names = TRUE, pattern = "\\.R"))'
 
 install:        ## Install the package locally via devtools::install()
 	Rscript -e 'devtools::install(upgrade = "never")'

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # MadRat commons Input Data Library
 
-R package **mrcommons**, version **1.25.18**
+R package **mrcommons**, version **1.25.19**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/mrcommons)](https://cran.r-project.org/package=mrcommons) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3822009.svg)](https://doi.org/10.5281/zenodo.3822009) [![R build status](https://github.com/pik-piam/mrcommons/workflows/check/badge.svg)](https://github.com/pik-piam/mrcommons/actions) [![codecov](https://codecov.io/gh/pik-piam/mrcommons/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrcommons) [![r-universe](https://pik-piam.r-universe.dev/badges/mrcommons)](https://pik-piam.r-universe.dev/ui#builds)
+[![CRAN status](https://www.r-pkg.org/badges/version/mrcommons)](https://cran.r-project.org/package=mrcommons) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3822009.svg)](https://doi.org/10.5281/zenodo.3822009) [![R build status](https://github.com/pik-piam/mrcommons/workflows/check/badge.svg)](https://github.com/pik-piam/mrcommons/actions) [![codecov](https://codecov.io/gh/pik-piam/mrcommons/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrcommons) [![r-universe](https://pik-piam.r-universe.dev/badges/mrcommons)](https://pik-piam.r-universe.dev/builds)
 
 ## Purpose and Functionality
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **mrcommons** in publications use:
 
-Bodirsky B, Karstens K, Baumstark L, Weindl I, Wang X, Mishra A, Wirth S, Stevanovic M, Steinmetz N, Kreidenweis U, Rodrigues R, Popov R, Humpenoeder F, Giannousakis A, Levesque A, Klein D, Araujo E, Beier F, Oeser J, Pehl M, Leip D, Crawford M, Molina Bacca E, von Jeetze P, Martinelli E, Schreyer F, Soergel B, Führlich P, Hötten D, Hasse R, Dietrich J (2023). _mrcommons: MadRat commons Input Data Library_. doi:10.5281/zenodo.3822009 <https://doi.org/10.5281/zenodo.3822009>, R package version 1.25.18, <https://github.com/pik-piam/mrcommons>.
+Bodirsky B, Karstens K, Baumstark L, Weindl I, Wang X, Mishra A, Wirth S, Stevanovic M, Steinmetz N, Kreidenweis U, Rodrigues R, Popov R, Humpenoeder F, Giannousakis A, Levesque A, Klein D, Araujo E, Beier F, Oeser J, Pehl M, Leip D, Crawford M, Molina Bacca E, von Jeetze P, Martinelli E, Schreyer F, Soergel B, Führlich P, Hötten D, Hasse R, Dietrich J (2023). _mrcommons: MadRat commons Input Data Library_. doi:10.5281/zenodo.3822009 <https://doi.org/10.5281/zenodo.3822009>, R package version 1.25.19, <https://github.com/pik-piam/mrcommons>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrcommons: MadRat commons Input Data Library},
   author = {Benjamin Leon Bodirsky and Kristine Karstens and Lavinia Baumstark and Isabelle Weindl and Xiaoxi Wang and Abhijeet Mishra and Stephen Wirth and Mishko Stevanovic and Nele Steinmetz and Ulrich Kreidenweis and Renato Rodrigues and Roman Popov and Florian Humpenoeder and Anastasis Giannousakis and Antoine Levesque and David Klein and Ewerton Araujo and Felicitas Beier and Julian Oeser and Michaja Pehl and Debbora Leip and Michael Crawford and Edna {Molina Bacca} and Patrick {von Jeetze} and Eleonora Martinelli and Felix Schreyer and Bjoern Soergel and Pascal Führlich and David Hötten and Robin Hasse and Jan Philipp Dietrich},
   year = {2023},
-  note = {R package version 1.25.18},
+  note = {R package version 1.25.19},
   doi = {10.5281/zenodo.3822009},
   url = {https://github.com/pik-piam/mrcommons},
 }


### PR DESCRIPTION
Just re-build mrcommons to get the latest Makefile updates with the nice `lint-all` target.