### PR TITLE
Improve conversion

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '24468444'
+ValidationKey: '24489110'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "mrcommons: MadRat commons Input Data Library",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "description": "<p>Provides useful functions and a common structure to all the input data required to run models like MAgPIE\n    and REMIND of model input data.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mrcommons
 Type: Package
 Title: MadRat commons Input Data Library
-Version: 1.26.1
-Date: 2023-02-16
+Version: 1.26.2
+Date: 2023-02-17
 Authors@R: c(person("Benjamin Leon", "Bodirsky", email = "bodirsky@pik-potsdam.de", role = "aut"),
              person("Kristine", "Karstens", role = "aut"),
              person("Lavinia", "Baumstark", role = "aut"),

--- a/R/convertVittis.R
+++ b/R/convertVittis.R
@@ -15,8 +15,8 @@ convertVittis <- function(x) {
     toolAggregate(mapping, from = "ProductionItem", to = "Vittis", dim = 3)
   x <- toolAggregate(x, mapping, weight = weights, from = "Vittis", to = "kcr", dim = 3.2)
 
-  # Convert from "constant 2000 US$MER" to "constant 2010 US$MER"
-  x <- GDPuc::convertGDP(x, "constant 2000 US$MER", "constant 2010 US$MER", replace_NAs = c("linear", 0))
+  # Convert from "constant 2000 Int$PPP" to "constant 2005 Int$PPP"
+  x <- GDPuc::convertGDP(x, "constant 2000 Int$PPP", "constant 2005 Int$PPP", replace_NAs = c("linear", 0))
 
   # fill missing countries with average over corresponding world region
   mapping <- toolGetMapping("regionmappingH12.csv", type = "regional")

--- a/R/convertVittis.R
+++ b/R/convertVittis.R
@@ -9,22 +9,22 @@
 convertVittis <- function(x) {
   # map to MAgPIE categories with global crop areas as weights
   mapping <- toolGetMapping("VittisCropCategories.csv", type = "sectoral", where = "mrcommons")
-  weights <- toolAggregate(calcOutput("Croparea", sectoral = "ProductionItem", aggregate = "GLO")[, "y2000", unique(mapping[, "ProductionItem"])], mapping, from = "ProductionItem", to = "Vittis", dim = 3)
+  weights <- calcOutput("Croparea",
+                        sectoral = "ProductionItem",
+                        aggregate = "GLO")[, "y2000", unique(mapping[, "ProductionItem"])] %>%
+    toolAggregate(mapping, from = "ProductionItem", to = "Vittis", dim = 3)
   x <- toolAggregate(x, mapping, weight = weights, from = "Vittis", to = "kcr", dim = 3.2)
 
-  # convert US$2000 to US$2005
-  ppp_current <- readSource("WDI", subtype = "NY.GDP.MKTP.PP.CD")
-  ppp_2011 <- readSource("WDI", "NY.GDP.MKTP.PP.KD") # 2011 ppp dataset
-
-  PPPratio2011to2005 <- setYears(ppp_current["USA", "y2005", ] / ppp_2011["USA", "y2005", ], NULL)
-  PPPratio2011to2000 <- setYears(ppp_current["USA", "y2000", ] / ppp_2011["USA", "y2000", ], NULL)
-  PPPratio2000to2005 <- collapseDim(PPPratio2011to2005 / PPPratio2011to2000, dim = c(1, 3))
-
-  x <- x * PPPratio2000to2005
+  # Convert from "constant 2000 US$MER" to "constant 2010 US$MER"
+  x <- GDPuc::convertGDP(x, "constant 2000 US$MER", "constant 2010 US$MER", replace_NAs = c("linear", 0))
 
   # fill missing countries with average over corresponding world region
   mapping <- toolGetMapping("regionmappingH12.csv", type = "regional")
-  avg_costs <- toolAggregate(x, rel = mapping[mapping[, 2] %in% getRegions(x), ], from = "CountryCode", to = "RegionCode", weight = new.magpie(getRegions(x), getYears(x), getNames(x), 1))
+  avg_costs <- toolAggregate(x,
+                             rel = mapping[mapping[, 2] %in% getRegions(x), ],
+                             from = "CountryCode",
+                             to = "RegionCode",
+                             weight = new.magpie(getRegions(x), getYears(x), getNames(x), 1))
   missing_countries <- setdiff(mapping[, 2], getRegions(x))
   x <- toolCountryFill(x, verbosity = 2)
   for (reg in missing_countries) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat commons Input Data Library
 
-R package **mrcommons**, version **1.26.1**
+R package **mrcommons**, version **1.26.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrcommons)](https://cran.r-project.org/package=mrcommons) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3822009.svg)](https://doi.org/10.5281/zenodo.3822009) [![R build status](https://github.com/pik-piam/mrcommons/workflows/check/badge.svg)](https://github.com/pik-piam/mrcommons/actions) [![codecov](https://codecov.io/gh/pik-piam/mrcommons/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrcommons) [![r-universe](https://pik-piam.r-universe.dev/badges/mrcommons)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **mrcommons** in publications use:
 
-Bodirsky B, Karstens K, Baumstark L, Weindl I, Wang X, Mishra A, Wirth S, Stevanovic M, Steinmetz N, Kreidenweis U, Rodrigues R, Popov R, Humpenoeder F, Giannousakis A, Levesque A, Klein D, Araujo E, Beier F, Oeser J, Pehl M, Leip D, Crawford M, Molina Bacca E, von Jeetze P, Martinelli E, Schreyer F, Soergel B, Führlich P, Hötten D, Hasse R, Dietrich J (2023). _mrcommons: MadRat commons Input Data Library_. doi:10.5281/zenodo.3822009 <https://doi.org/10.5281/zenodo.3822009>, R package version 1.26.1, <https://github.com/pik-piam/mrcommons>.
+Bodirsky B, Karstens K, Baumstark L, Weindl I, Wang X, Mishra A, Wirth S, Stevanovic M, Steinmetz N, Kreidenweis U, Rodrigues R, Popov R, Humpenoeder F, Giannousakis A, Levesque A, Klein D, Araujo E, Beier F, Oeser J, Pehl M, Leip D, Crawford M, Molina Bacca E, von Jeetze P, Martinelli E, Schreyer F, Soergel B, Führlich P, Hötten D, Hasse R, Dietrich J (2023). _mrcommons: MadRat commons Input Data Library_. doi: 10.5281/zenodo.3822009 (URL: https://doi.org/10.5281/zenodo.3822009), R package version 1.26.2, <URL: https://github.com/pik-piam/mrcommons>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrcommons: MadRat commons Input Data Library},
   author = {Benjamin Leon Bodirsky and Kristine Karstens and Lavinia Baumstark and Isabelle Weindl and Xiaoxi Wang and Abhijeet Mishra and Stephen Wirth and Mishko Stevanovic and Nele Steinmetz and Ulrich Kreidenweis and Renato Rodrigues and Roman Popov and Florian Humpenoeder and Anastasis Giannousakis and Antoine Levesque and David Klein and Ewerton Araujo and Felicitas Beier and Julian Oeser and Michaja Pehl and Debbora Leip and Michael Crawford and Edna {Molina Bacca} and Patrick {von Jeetze} and Eleonora Martinelli and Felix Schreyer and Bjoern Soergel and Pascal Führlich and David Hötten and Robin Hasse and Jan Philipp Dietrich},
   year = {2023},
-  note = {R package version 1.26.1},
+  note = {R package version 1.26.2},
   doi = {10.5281/zenodo.3822009},
   url = {https://github.com/pik-piam/mrcommons},
 }


### PR DESCRIPTION
Hey :)
I'm in the process of preparing a mrdrivers update, and as a part of that I'm trying to slim down the WDI download (which happens in mrdrivers. The readSource calls of "NY.GDP.MKTP.PP.CD"  (which across all our packages appears only here) could/should be eliminated I think.

In general the GDPuc::convertGDP is more accurate in conversions, and also more in sync with how we do it in other places. Unless you feel that it isn't applicable here?
One thing I'm not certain about, is what unit you actually have/want (MER vs PPP). Below I assume MERs.