### PR TITLE
Update bioamss supplycurves

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '29268213'
+ValidationKey: '29291170'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrcommons: MadRat commons Input Data Library'
-version: 1.46.1
-date-released: '2024-11-06'
+version: 1.46.2
+date-released: '2024-11-08'
 abstract: Provides useful functions and a common structure to all the input data required
   to run models like MAgPIE and REMIND of model input data.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mrcommons
 Type: Package
 Title: MadRat commons Input Data Library
-Version: 1.46.1
-Date: 2024-11-06
+Version: 1.46.2
+Date: 2024-11-08
 Authors@R: c(person("Benjamin Leon", "Bodirsky", email = "bodirsky@pik-potsdam.de", role = "aut"),
              person("Kristine", "Karstens", role = "aut"),
              person("Lavinia", "Baumstark", role = "aut"),

--- a/R/calcMAgPIEReport.R
+++ b/R/calcMAgPIEReport.R
@@ -98,6 +98,11 @@ calcMAgPIEReport <- function(subtype) {
   getNames(tmp) <- gsub("SSP2", "SSP3", getNames(tmp))
   x <- mbind(x, tmp)
 
+  # add values for SSP2_lowEn copying the values from SSP2
+  tmp <- x[, , "SSP2"]
+  getNames(tmp) <- gsub("SSP2", "SSP2_lowEn", getNames(tmp))
+  x <- mbind(x, tmp)
+
   return(list(
     x = x,
     weight = NULL,

--- a/R/readMAgPIE.R
+++ b/R/readMAgPIE.R
@@ -16,7 +16,7 @@
 readMAgPIE <- function(subtype) {
 
   # input data version
-  ver <- "2023-12"
+  ver <- "2024-11"
 
   if (subtype == "EmiAirPoll") {
     x <- read.csv(file.path(ver, "emiAPexo.csv"), row.names = 1)
@@ -76,21 +76,20 @@ readMAgPIE <- function(subtype) {
     # Please update scenario names in mrremind::calcBiomassPrices.R if necessary
 
     scenarioNames <- c(
-      "f30_bioen_price_SDP-MC-NDC-nocc_hist-NDC_replaced_flat",
-      "f30_bioen_price_SDP-MC-NDC-nocc_hist-PkBudg650_replaced_flat",
-      "f30_bioen_price_SDP-MC-NPI-nocc_hist-Base_replaced_flat",
-      "f30_bioen_price_SSP1-NDC-nocc_hist-NDC_replaced_flat",
-      "f30_bioen_price_SSP1-NDC-nocc_hist-PkBudg1050_replaced_flat",
-      "f30_bioen_price_SSP1-NDC-nocc_hist-PkBudg650_replaced_flat",
-      "f30_bioen_price_SSP1-NPI-nocc_hist-Base_replaced_flat",
-      "f30_bioen_price_SSP2-NDC-nocc_hist-NDC_replaced_flat",
-      "f30_bioen_price_SSP2-NDC-nocc_hist-PkBudg1050_replaced_flat",
-      "f30_bioen_price_SSP2-NDC-nocc_hist-PkBudg650_replaced_flat",
-      "f30_bioen_price_SSP2-NPI-nocc_hist-Base_replaced_flat",
-      "f30_bioen_price_SSP5-NDC-nocc_hist-NDC_replaced_flat",
-      "f30_bioen_price_SSP5-NDC-nocc_hist-PkBudg1050_replaced_flat",
-      "f30_bioen_price_SSP5-NDC-nocc_hist-PkBudg650_replaced_flat",
-      "f30_bioen_price_SSP5-NPI-nocc_hist-Base_replaced_flat"
+      "f30_bioen_price_SSP1-SSP1-NPi_replaced_flat_62eff8f7.cs4r",
+      "f30_bioen_price_SSP1-SSP1-PkBudg650_replaced_flat_62eff8f7.cs4r",
+      "f30_bioen_price_SSP2-SSP2_lowEn-NPi_replaced_flat_62eff8f7.cs4r",
+      "f30_bioen_price_SSP2-SSP2_lowEn-PkBudg1000_replaced_flat_62eff8f7.cs4r",
+      "f30_bioen_price_SSP2-SSP2_lowEn-PkBudg650_replaced_flat_62eff8f7.cs4r",
+      "f30_bioen_price_SSP2-SSP2-NPi_replaced_flat_62eff8f7.cs4r",
+      "f30_bioen_price_SSP2-SSP2-PkBudg1000_replaced_flat_62eff8f7.cs4r",
+      "f30_bioen_price_SSP2-SSP2-PkBudg650_replaced_flat_62eff8f7.cs4r",
+      "f30_bioen_price_SSP3-SSP2-NPi_replaced_flat_62eff8f7.cs4r",
+      "f30_bioen_price_SSP3-SSP2-PkBudg1000_replaced_flat_62eff8f7.cs4r",
+      "f30_bioen_price_SSP3-SSP2-PkBudg650_replaced_flat_62eff8f7.cs4r",
+      "f30_bioen_price_SSP5-SSP5-NPi_replaced_flat_62eff8f7.cs4r",
+      "f30_bioen_price_SSP5-SSP5-PkBudg1000_replaced_flat_62eff8f7.cs4r",
+      "f30_bioen_price_SSP5-SSP5-PkBudg650_replaced_flat_62eff8f7.cs4r"
     )
 
     fileList <- file.path(ver, paste0(scenarioNames, regcode, ".cs4r"))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat commons Input Data Library
 
-R package **mrcommons**, version **1.46.1**
+R package **mrcommons**, version **1.46.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrcommons)](https://cran.r-project.org/package=mrcommons) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3822009.svg)](https://doi.org/10.5281/zenodo.3822009) [![R build status](https://github.com/pik-piam/mrcommons/workflows/check/badge.svg)](https://github.com/pik-piam/mrcommons/actions) [![codecov](https://codecov.io/gh/pik-piam/mrcommons/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrcommons) [![r-universe](https://pik-piam.r-universe.dev/badges/mrcommons)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **mrcommons** in publications use:
 
-Bodirsky B, Karstens K, Baumstark L, Weindl I, Wang X, Mishra A, Wirth S, Stevanovic M, Steinmetz N, Kreidenweis U, Rodrigues R, Popov R, Humpenoeder F, Giannousakis A, Levesque A, Klein D, Araujo E, Beier F, Oeser J, Pehl M, Leip D, Crawford M, Molina Bacca E, von Jeetze P, Martinelli E, Schreyer F, Soergel B, Sauer P, Hötten D, Hasse R, Abrahão G, Weigmann P, Dietrich J (2024). _mrcommons: MadRat commons Input Data Library_. doi:10.5281/zenodo.3822009 <https://doi.org/10.5281/zenodo.3822009>, R package version 1.46.1, <https://github.com/pik-piam/mrcommons>.
+Bodirsky B, Karstens K, Baumstark L, Weindl I, Wang X, Mishra A, Wirth S, Stevanovic M, Steinmetz N, Kreidenweis U, Rodrigues R, Popov R, Humpenoeder F, Giannousakis A, Levesque A, Klein D, Araujo E, Beier F, Oeser J, Pehl M, Leip D, Crawford M, Molina Bacca E, von Jeetze P, Martinelli E, Schreyer F, Soergel B, Sauer P, Hötten D, Hasse R, Abrahão G, Weigmann P, Dietrich J (2024). _mrcommons: MadRat commons Input Data Library_. doi:10.5281/zenodo.3822009 <https://doi.org/10.5281/zenodo.3822009>, R package version 1.46.2, <https://github.com/pik-piam/mrcommons>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,8 +48,8 @@ A BibTeX entry for LaTeX users is
   title = {mrcommons: MadRat commons Input Data Library},
   author = {Benjamin Leon Bodirsky and Kristine Karstens and Lavinia Baumstark and Isabelle Weindl and Xiaoxi Wang and Abhijeet Mishra and Stephen Wirth and Mishko Stevanovic and Nele Steinmetz and Ulrich Kreidenweis and Renato Rodrigues and Roman Popov and Florian Humpenoeder and Anastasis Giannousakis and Antoine Levesque and David Klein and Ewerton Araujo and Felicitas Beier and Julian Oeser and Michaja Pehl and Debbora Leip and Michael Crawford and Edna {Molina Bacca} and Patrick {von Jeetze} and Eleonora Martinelli and Felix Schreyer and Bjoern Soergel and Pascal Sauer and David Hötten and Robin Hasse and Gabriel Abrahão and Pascal Weigmann and Jan Philipp Dietrich},
   year = {2024},
-  note = {R package version 1.46.1},
-  doi = {10.5281/zenodo.3822009},
+  note = {R package version 1.46.2},
   url = {https://github.com/pik-piam/mrcommons},
+  doi = {10.5281/zenodo.3822009},
 }
 ```


### PR DESCRIPTION
Read new biomass supplycurves from MAgPIE magpie_4.8.1 including SSP3 and unit shift (US$2017). Other input data from MAgPIE (emissions, costs) remain unchanged.