### PR TITLE
Update MAgPIE emissions and costs

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '31390789'
+ValidationKey: '31412556'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrcommons: MadRat commons Input Data Library'
-version: 1.55.3
-date-released: '2025-05-05'
+version: 1.55.4
+date-released: '2025-05-06'
 abstract: Provides useful functions and a common structure to all the input data required
   to run models like MAgPIE and REMIND of model input data.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrcommons
 Title: MadRat commons Input Data Library
-Version: 1.55.3
-Date: 2025-05-05
+Version: 1.55.4
+Date: 2025-05-06
 Authors@R: c(
     person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = "aut"),
     person("Kristine", "Karstens", role = "aut"),

--- a/R/calcMAgPIEReport.R
+++ b/R/calcMAgPIEReport.R
@@ -70,9 +70,9 @@ calcMAgPIEReport <- function(subtype) {
   getNames(x) <- getNames(x) %>%
     stringr::str_replace_all(c(
       "^C_"               = "",
-      "-PkBudg650-rawluc-mag-4"  = ".rcp20",
-      "-PkBudg1000-rawluc-mag-4" = ".rcp26",
-      "-NPi2025-rawluc-mag-4"    = ".rcp45"
+      "-PkBudg650-mag-4"  = ".rcp20",
+      "-PkBudg1000-mag-4" = ".rcp26",
+      "-NPi2025-mag-4"    = ".rcp45"
       # "-Base-mag-4"       = ".none",  # nolint
     ))
 

--- a/R/readMAgPIE.R
+++ b/R/readMAgPIE.R
@@ -16,7 +16,7 @@
 readMAgPIE <- function(subtype) {
 
   # input data version
-  ver <- "2025-03"
+  ver <- "2025-04"
 
   if (subtype == "EmiAirPoll") {
     x <- read.csv(file.path(ver, "emiAPexo.csv"), row.names = 1)
@@ -48,20 +48,20 @@ readMAgPIE <- function(subtype) {
     # !!! ATTENTION !!!
     # Please update scenario names in calcMAgPIEReport.R
 
-    fileList <- c("C_SSP1-NPi2025-rawluc-mag-4.mif",
-                  "C_SSP1-PkBudg1000-rawluc-mag-4.mif",
-                  "C_SSP1-PkBudg650-rawluc-mag-4.mif",
-                  "C_SSP2_lowEn-NPi2025-rawluc-mag-4.mif",
-                  "C_SSP2_lowEn-PkBudg1000-rawluc-mag-4.mif",
-                  "C_SSP2_lowEn-PkBudg650-rawluc-mag-4.mif",
-                  "C_SSP2-NPi2025-rawluc-mag-4.mif",
-                  "C_SSP2-PkBudg1000-rawluc-mag-4.mif",
-                  "C_SSP2-PkBudg650-rawluc-mag-4.mif",
-                  "C_SSP3-NPi2025-rawluc-mag-4.mif",
-                  "C_SSP3-PkBudg1000-rawluc-mag-4.mif",
-                  "C_SSP5-NPi2025-rawluc-mag-4.mif",
-                  "C_SSP5-PkBudg1000-rawluc-mag-4.mif",
-                  "C_SSP5-PkBudg650-rawluc-mag-4.mif")
+    fileList <- c("C_SSP1-NPi2025-mag-4.mif",
+                  "C_SSP1-PkBudg1000-mag-4.mif",
+                  "C_SSP1-PkBudg650-mag-4.mif",
+                  "C_SSP2_lowEn-NPi2025-mag-4.mif",
+                  "C_SSP2_lowEn-PkBudg1000-mag-4.mif",
+                  "C_SSP2_lowEn-PkBudg650-mag-4.mif",
+                  "C_SSP2-NPi2025-mag-4.mif",
+                  "C_SSP2-PkBudg1000-mag-4.mif",
+                  "C_SSP2-PkBudg650-mag-4.mif",
+                  "C_SSP3-NPi2025-mag-4.mif",
+                  "C_SSP3-PkBudg1000-mag-4.mif",
+                  "C_SSP5-NPi2025-mag-4.mif",
+                  "C_SSP5-PkBudg1000-mag-4.mif",
+                  "C_SSP5-PkBudg650-mag-4.mif")
 
     x <- NULL
     for (f in fileList) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat commons Input Data Library
 
-R package **mrcommons**, version **1.55.3**
+R package **mrcommons**, version **1.55.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrcommons)](https://cran.r-project.org/package=mrcommons) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3822009.svg)](https://doi.org/10.5281/zenodo.3822009) [![R build status](https://github.com/pik-piam/mrcommons/workflows/check/badge.svg)](https://github.com/pik-piam/mrcommons/actions) [![codecov](https://codecov.io/gh/pik-piam/mrcommons/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrcommons) [![r-universe](https://pik-piam.r-universe.dev/badges/mrcommons)](https://pik-piam.r-universe.dev/builds)
 
@@ -40,18 +40,18 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **mrcommons** in publications use:
 
-Bodirsky B, Karstens K, Baumstark L, Weindl I, Wang X, Mishra A, Wirth S, Stevanovic M, Steinmetz N, Kreidenweis U, Rodrigues R, Popov R, Humpenoeder F, Giannousakis A, Levesque A, Klein D, Araujo E, Bleidorn E, Beier F, Oeser J, Pehl M, Leip D, Crawford M, Molina Bacca E, von Jeetze P, Martinelli E, Schreyer F, Soergel B, Sauer P, HÃ¶tten D, Hasse R, AbrahÃ£o G, Weigmann P, Dietrich J (2025). "mrcommons: MadRat commons Input Data Library." doi:10.5281/zenodo.3822009 <https://doi.org/10.5281/zenodo.3822009>, Version: 1.55.3, <https://github.com/pik-piam/mrcommons>.
+Bodirsky B, Karstens K, Baumstark L, Weindl I, Wang X, Mishra A, Wirth S, Stevanovic M, Steinmetz N, Kreidenweis U, Rodrigues R, Popov R, Humpenoeder F, Giannousakis A, Levesque A, Klein D, Araujo E, Bleidorn E, Beier F, Oeser J, Pehl M, Leip D, Crawford M, Molina Bacca E, von Jeetze P, Martinelli E, Schreyer F, Soergel B, Sauer P, Hötten D, Hasse R, Abrahão G, Weigmann P, Dietrich J (2025). "mrcommons: MadRat commons Input Data Library." doi:10.5281/zenodo.3822009 <https://doi.org/10.5281/zenodo.3822009>, Version: 1.55.4, <https://github.com/pik-piam/mrcommons>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
   title = {mrcommons: MadRat commons Input Data Library},
-  author = {Benjamin Leon Bodirsky and Kristine Karstens and Lavinia Baumstark and Isabelle Weindl and Xiaoxi Wang and Abhijeet Mishra and Stephen Wirth and Mishko Stevanovic and Nele Steinmetz and Ulrich Kreidenweis and Renato Rodrigues and Roman Popov and Florian Humpenoeder and Anastasis Giannousakis and Antoine Levesque and David Klein and Ewerton Araujo and Eva Bleidorn and Felicitas Beier and Julian Oeser and Michaja Pehl and Debbora Leip and Michael Crawford and Edna {Molina Bacca} and Patrick {von Jeetze} and Eleonora Martinelli and Felix Schreyer and Bjoern Soergel and Pascal Sauer and David HÃ¶tten and Robin Hasse and Gabriel AbrahÃ£o and Pascal Weigmann and Jan Philipp Dietrich},
+  author = {Benjamin Leon Bodirsky and Kristine Karstens and Lavinia Baumstark and Isabelle Weindl and Xiaoxi Wang and Abhijeet Mishra and Stephen Wirth and Mishko Stevanovic and Nele Steinmetz and Ulrich Kreidenweis and Renato Rodrigues and Roman Popov and Florian Humpenoeder and Anastasis Giannousakis and Antoine Levesque and David Klein and Ewerton Araujo and Eva Bleidorn and Felicitas Beier and Julian Oeser and Michaja Pehl and Debbora Leip and Michael Crawford and Edna {Molina Bacca} and Patrick {von Jeetze} and Eleonora Martinelli and Felix Schreyer and Bjoern Soergel and Pascal Sauer and David Hötten and Robin Hasse and Gabriel Abrahão and Pascal Weigmann and Jan Philipp Dietrich},
   doi = {10.5281/zenodo.3822009},
-  date = {2025-05-05},
+  date = {2025-05-06},
   year = {2025},
   url = {https://github.com/pik-piam/mrcommons},
-  note = {Version: 1.55.3},
+  note = {Version: 1.55.4},
 }
 ```


### PR DESCRIPTION
## What changes
With this PR the following data are updated that are only used in REMIND standalone runs (coupled runs take them from the previous MAgPIE iteration directly):

- Land use emissions for CO2, CH4, and N2O
- Total agricultural production costs that go into the budget equation
- Bioenergy production to calculate bioenergy production costs that need to be substracted from the total agricultural production costs to avoid double counting
- Abatement costs: In standalone runs costs for abating land use emissions are calcualted endogenously in REMIND. Since they are also included in the exogenous total landuse costs they need to be substracted from these total landuse costs. In coupled runs the land use MAC is deactivated in REMIND, abatement costs are included in the total land use costs that are transferred from MAgPIE.
- not updated in this PR: bioenergy supply curves

## Procedure
More details on the procedure [here](https://gitlab.pik-potsdam.de/REMIND/wiki/-/wikis/Updating-Inputs-from-MagPIE#1-remind-inputs-directly-generated-from-magpie-reports).

## Data source
The data is read from MAgPIE reports from coupled runs here `/p/projects/remind/runs/REMIND-MAgPIE-2025-04-24/magpie/`. 
This file `/p/projects/rd3mod/inputdata/sources/MAgPIE/2025-04/copy-magpie-reports.sh` documents all data sources for version "2025-04" in `mrcommons::readMAgPIE`.

## Model versions used in the coupled runs

- MAgPIE master branch, release 4.10.0

```
commit b53700c574066f950597a35553787754485919a5 (HEAD -> master, origin/master, origin/HEAD)
Merge: 5511cc7a0 1d32c6f54
Author: Pascal Sauer <156898545+pascal-sauer@users.noreply.github.com>
Date:   Fri Apr 4 14:19:45 2025 +0200

    Merge pull request #795 from magpiemodel/revert-794-master-into-develop

    Revert "merge master into develop"
```

- REMIND develop branch, 3.5.0.dev85

```
commit 7d251929db173d82f9c16486433045d9e68bbcf9 (HEAD -> develop, origin/develop, origin/HEAD)
Author: REMIND Research Software Engineering <rse@pik-potsdam.de>
Date:   Thu Apr 24 12:51:46 2025 +0000

    Release development version 3.5.0.dev85
```

## Comparison 2025-04 (this version) vs. 2025-03 (previous version)

No significant changes in almost all variables, except MAC costs, because this remindmodel/remind#2089 caps the price in MAgPIE for CH4 and N20 at 200 US$2017 in order not to drive up food prices excessively, without significant changes in emission mitigation. The limited price on CH4 and N2O results in lower MAC costs:

![image](https://github.com/user-attachments/assets/973b87b7-993e-4c1b-89bf-73068533477e)

All comparision files can be found here `/p/projects/rd3mod/inputdata/sources/MAgPIE/2025-04`