### PR TITLE
Add subcategories of co2luc

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '31616442'
+ValidationKey: '31784650'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrcommons: MadRat commons Input Data Library'
-version: 1.56.2
-date-released: '2025-06-02'
+version: 1.57.0
+date-released: '2025-06-06'
 abstract: Provides useful functions and a common structure to all the input data required
   to run models like MAgPIE and REMIND of model input data.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrcommons
 Title: MadRat commons Input Data Library
-Version: 1.56.2
-Date: 2025-06-02
+Version: 1.57.0
+Date: 2025-06-06
 Authors@R: c(
     person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = "aut"),
     person("Kristine", "Karstens", role = "aut"),

--- a/R/calcMAgPIEReport.R
+++ b/R/calcMAgPIEReport.R
@@ -46,13 +46,33 @@ calcMAgPIEReport <- function(subtype) {
 
   } else if (subtype == "co2") {
     mapping <- inline.data.frame(
-      "oldnames;newnames",
-      "Emissions|CO2|Land RAW|+|Land-use Change (Mt CO2/yr);co2luc"
+      "magpieNames;remindNames",
+      "Emissions|CO2|Land RAW|+|Land-use Change (Mt CO2/yr);co2luc",
+      "Emissions|CO2|Land RAW|Land-use Change|+|Deforestation (Mt CO2/yr);co2lucPos",
+      "Emissions|CO2|Land RAW|Land-use Change|+|Forest degradation (Mt CO2/yr);co2lucPos",
+      "Emissions|CO2|Land RAW|Land-use Change|+|Other land conversion (Mt CO2/yr);co2lucPos",
+      "Emissions|CO2|Land RAW|Land-use Change|+|Wood Harvest (Mt CO2/yr);co2lucPos",
+      "Emissions|CO2|Land RAW|Land-use Change|Peatland|+|Positive (Mt CO2/yr);co2lucPos",
+      "Emissions|CO2|Land RAW|Land-use Change|Peatland|+|Negative (Mt CO2/yr);co2lucNegIntentPeat",
+      "Emissions|CO2|Land RAW|Land-use Change|Regrowth|+|CO2-price AR (Mt CO2/yr);co2lucNegIntentAR",
+      "Emissions|CO2|Land RAW|Land-use Change|Regrowth|+|NPI_NDC AR (Mt CO2/yr);co2lucNegIntentAR",
+      "Emissions|CO2|Land RAW|Land-use Change|Regrowth|+|Cropland Tree Cover (Mt CO2/yr);co2lucNegIntentAgroforestry",
+      "Emissions|CO2|Land RAW|Land-use Change|Regrowth|+|Other Land (Mt CO2/yr);co2lucNegUnintent",
+      "Emissions|CO2|Land RAW|Land-use Change|Regrowth|+|Secondary Forest (Mt CO2/yr);co2lucNegUnintent",
+      "Emissions|CO2|Land RAW|Land-use Change|Regrowth|+|Timber Plantations (Mt CO2/yr);co2lucNegUnintent",
+      "Emissions|CO2|Land RAW|Land-use Change|Residual|+|Positive (Mt CO2/yr);co2lucPos",
+      "Emissions|CO2|Land RAW|Land-use Change|Residual|+|Negative (Mt CO2/yr);co2lucNegUnintent",
+      "Emissions|CO2|Land RAW|Land-use Change|Soil|++|Emissions (Mt CO2/yr);co2lucPos",
+      "Emissions|CO2|Land RAW|Land-use Change|Soil|Cropland management|+|Withdrawals (Mt CO2/yr);co2lucNegUnintent",
+      "Emissions|CO2|Land RAW|Land-use Change|Soil|Land Conversion|+|Withdrawals (Mt CO2/yr);co2lucNegUnintent",
+      "Emissions|CO2|Land RAW|Land-use Change|Soil|Soil Carbon Management|+|Withdrawals (Mt CO2/yr);co2lucNegIntentSCM",
+      "Emissions|CO2|Land RAW|Land-use Change|Timber|+|Storage in HWP (Mt CO2/yr);co2lucNegIntentTimber",
+      "Emissions|CO2|Land RAW|Land-use Change|Timber|+|Release from HWP (Mt CO2/yr);co2lucPos"
     )
 
-    x <- x[, , mapping$oldnames]
-    # rename
-    getNames(x, dim = 3) <- mapping$newnames
+    # aggregate (sum over) MAgPIE variables to REMIND entys
+    x <- toolAggregate(x[,,mapping$magpieNames], rel = mapping, from = "magpieNames", to = "remindNames", dim = 3.3)
+
     d <- "CO2 land emissions"
     u <- "Mt CO2/yr"
 

--- a/R/calcMacBaseLandUse.R
+++ b/R/calcMacBaseLandUse.R
@@ -17,9 +17,11 @@ calcMacBaseLandUse <- function(subtype) {
   # Create empty magclass object with all dimensions that can be filled below (so it's
   # easy to see which entries remain empty afterwards)
   isoCountry <- read.csv2(system.file("extdata", "iso_country.csv", package = "madrat"), row.names = NULL)
-  sources    <- c("co2luc", "n2oanwstm", "n2ofertin", "n2oanwstc", "n2ofertcr", "n2ofertsom", "n2ofertrb", "n2oanwstp",
-                  "n2opeatland", "n2oforest", "n2osavan", "n2oagwaste", "ch4rice", "ch4anmlwst", "ch4animals",
-                  "ch4peatland", "ch4forest", "ch4savan", "ch4agwaste")
+  sources    <- c("co2luc", "co2lucPos", "co2lucNegUnintent", "co2lucNegIntentAR", "co2lucNegIntentAgroforestry",
+                  "co2lucNegIntentTimber", "co2lucNegIntentSCM", "co2lucNegIntentPeat", "n2oanwstm", "n2ofertin",
+                  "n2oanwstc", "n2ofertcr", "n2ofertsom", "n2ofertrb", "n2oanwstp", "n2opeatland", "n2oforest",
+                  "n2osavan", "n2oagwaste", "ch4rice", "ch4anmlwst", "ch4animals", "ch4peatland", "ch4forest",
+                  "ch4savan", "ch4agwaste")
 
   y <- new.magpie(cells_and_regions = isoCountry$x,
                   years = seq(2005, 2150, 5),
@@ -136,6 +138,13 @@ calcMacBaseLandUse <- function(subtype) {
 
     # emission types in REMIND that are updated with MAgPIE data
     emiMacMagpie <- c("co2luc",
+                      "co2lucPos",
+                      "co2lucNegUnintent",
+                      "co2lucNegIntentAR",
+                      "co2lucNegIntentAgroforestry",
+                      "co2lucNegIntentTimber",
+                      "co2lucNegIntentSCM",
+                      "co2lucNegIntentPeat",
                       "n2oanwstm",
                       "n2ofertin",
                       "n2oanwstc",
@@ -153,8 +162,6 @@ calcMacBaseLandUse <- function(subtype) {
     # Read CO2 LUC baseline for all SSPs/SDP from MAgPIE reports
     xCO2 <- calcOutput("MAgPIEReport", subtype = "co2", aggregate = FALSE, warnNA = FALSE)
     xCO2[, 1995, ] <- 0 # replace NA with 0 (only CO2 has NA in 1995)
-    xCO2 <- add_dimension(xCO2, dim = 3.3, nm = "co2luc")
-    getSets(xCO2) <- c("region", "year", "scenario", "variable", "data")
 
     # Read N2O, CH4 baseline for all SSPs/SDP from MAgPIE reports
     xCH4N2O <- calcOutput("MAgPIEReport", subtype = "ch4n2o", aggregate = FALSE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat commons Input Data Library
 
-R package **mrcommons**, version **1.56.2**
+R package **mrcommons**, version **1.57.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrcommons)](https://cran.r-project.org/package=mrcommons) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3822009.svg)](https://doi.org/10.5281/zenodo.3822009) [![R build status](https://github.com/pik-piam/mrcommons/workflows/check/badge.svg)](https://github.com/pik-piam/mrcommons/actions) [![codecov](https://codecov.io/gh/pik-piam/mrcommons/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrcommons) [![r-universe](https://pik-piam.r-universe.dev/badges/mrcommons)](https://pik-piam.r-universe.dev/builds)
 
@@ -40,7 +40,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **mrcommons** in publications use:
 
-Bodirsky B, Karstens K, Baumstark L, Weindl I, Wang X, Mishra A, Wirth S, Stevanovic M, Steinmetz N, Kreidenweis U, Rodrigues R, Popov R, Humpenoeder F, Giannousakis A, Levesque A, Klein D, Araujo E, Bleidorn E, Beier F, Oeser J, Pehl M, Leip D, Crawford M, Molina Bacca E, von Jeetze P, Martinelli E, Schreyer F, Soergel B, Sauer P, Hötten D, Hasse R, Abrahão G, Weigmann P, Dietrich J (2025). "mrcommons: MadRat commons Input Data Library." doi:10.5281/zenodo.3822009 <https://doi.org/10.5281/zenodo.3822009>, Version: 1.56.2, <https://github.com/pik-piam/mrcommons>.
+Bodirsky B, Karstens K, Baumstark L, Weindl I, Wang X, Mishra A, Wirth S, Stevanovic M, Steinmetz N, Kreidenweis U, Rodrigues R, Popov R, Humpenoeder F, Giannousakis A, Levesque A, Klein D, Araujo E, Bleidorn E, Beier F, Oeser J, Pehl M, Leip D, Crawford M, Molina Bacca E, von Jeetze P, Martinelli E, Schreyer F, Soergel B, Sauer P, Hötten D, Hasse R, Abrahão G, Weigmann P, Dietrich J (2025). "mrcommons: MadRat commons Input Data Library." doi:10.5281/zenodo.3822009 <https://doi.org/10.5281/zenodo.3822009>, Version: 1.57.0, <https://github.com/pik-piam/mrcommons>.
 
 A BibTeX entry for LaTeX users is
 
@@ -49,9 +49,9 @@ A BibTeX entry for LaTeX users is
   title = {mrcommons: MadRat commons Input Data Library},
   author = {Benjamin Leon Bodirsky and Kristine Karstens and Lavinia Baumstark and Isabelle Weindl and Xiaoxi Wang and Abhijeet Mishra and Stephen Wirth and Mishko Stevanovic and Nele Steinmetz and Ulrich Kreidenweis and Renato Rodrigues and Roman Popov and Florian Humpenoeder and Anastasis Giannousakis and Antoine Levesque and David Klein and Ewerton Araujo and Eva Bleidorn and Felicitas Beier and Julian Oeser and Michaja Pehl and Debbora Leip and Michael Crawford and Edna {Molina Bacca} and Patrick {von Jeetze} and Eleonora Martinelli and Felix Schreyer and Bjoern Soergel and Pascal Sauer and David Hötten and Robin Hasse and Gabriel Abrahão and Pascal Weigmann and Jan Philipp Dietrich},
   doi = {10.5281/zenodo.3822009},
-  date = {2025-06-02},
+  date = {2025-06-06},
   year = {2025},
   url = {https://github.com/pik-piam/mrcommons},
-  note = {Version: 1.56.2},
+  note = {Version: 1.57.0},
 }
 ```


### PR DESCRIPTION
Reads some of the CO2 land use variables from MAgPIE report and adds them to the REMIND input file. Addresses https://github.com/remindmodel/development_issues/issues/475