### PR TITLE
CEDS2025 Aircraft and Shipping fix 

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '32275410'
+ValidationKey: '32308437'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, master]
 
 jobs:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrcommons: MadRat commons Input Data Library'
-version: 1.59.0
-date-released: '2025-07-30'
+version: 1.59.1
+date-released: '2025-08-07'
 abstract: Provides useful functions and a common structure to all the input data required
   to run models like MAgPIE and REMIND of model input data.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrcommons
 Title: MadRat commons Input Data Library
-Version: 1.59.0
-Date: 2025-07-30
+Version: 1.59.1
+Date: 2025-08-07
 Authors@R: c(
     person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = "aut"),
     person("Kristine", "Karstens", role = "aut"),

--- a/R/convertCEDS2025.R
+++ b/R/convertCEDS2025.R
@@ -39,36 +39,29 @@ convertCEDS2025 <- function(x) {
   x[, , "no2_n"] <- x[, , "no2_n"] / 46 * 14
   x[, , "co2_c"] <- x[, , "co2_c"] / 44 * 12
 
-
-
-
-  # most shipping and aviation data is global only (except 1A3dii_Domestic-navigation
-  # regional). We want to distribute it evenly across all countries.
-  # Therefore, save global data because it will be removed by toolCountryfill
-
-  # 1A3dii_Domestic-navigation   regional (global value is zero )
-  # 1A3di_International-shipping global   (no regional values exist)
-  # 1A3ai_International-aviation global   (no regional values exist)
-  # 1A3aii_Domestic-aviation     global   (no regional values exist)
-
+  # international shipping and aviation data is global only.
+  # We want to distribute it evenly across all countries for now, so it will not
+  # be removed by toolCountryfill.
   varGlob <- c("1A3di_International-shipping",
-               "1A3ai_International-aviation",
-               "1A3aii_Domestic-aviation")
-  xGLO <- x["GLO", , varGlob]
+               "1A3ai_International-aviation")
 
-  # remove global values. Note: the sector 2A1_Cement-production has a global
-  # sum that is indentical to the sum over regions
+  xGLO <- x["GLO", , varGlob]
   x <- x["GLO", , invert = TRUE]
-  # fills missing ISO countires and remove unknown ISO countires
+
+  # fills missing ISO countires and remove unknown ISO countries
   x <- toolCountryFill(x, fill = 0)
 
   # Create weight 1 for xGLO
-  w <- new.magpie(getItems(x, dim = 1), getItems(x, dim = 2), getItems(xGLO, dim = 3), fill = 1)
+  w <- new.magpie(getItems(x, dim = 1),
+                  getItems(x, dim = 2),
+                  getItems(xGLO, dim = 3),
+                  fill = 1)
 
   # Create mapping of each country to GLO
   mapping <- data.frame(from = getItems(x, dim = 1), to = "GLO")
 
-  # Spread global shipping and aviation data evenly across countries and save it to regions of x
+  # Spread global shipping and aviation data evenly across countries and save it
+  # to regions of x
   x[, , varGlob] <- toolAggregate(xGLO, mapping, weight = w)
 
   return(x)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRat commons Input Data Library
 
-R package **mrcommons**, version **1.59.0**
+R package **mrcommons**, version **1.59.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrcommons)](https://cran.r-project.org/package=mrcommons) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3822009.svg)](https://doi.org/10.5281/zenodo.3822009) [![R build status](https://github.com/pik-piam/mrcommons/workflows/check/badge.svg)](https://github.com/pik-piam/mrcommons/actions) [![codecov](https://codecov.io/gh/pik-piam/mrcommons/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrcommons) [![r-universe](https://pik-piam.r-universe.dev/badges/mrcommons)](https://pik-piam.r-universe.dev/builds)
 
@@ -40,7 +40,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **mrcommons** in publications use:
 
-Bodirsky B, Karstens K, Baumstark L, Weindl I, Wang X, Mishra A, Wirth S, Stevanovic M, Steinmetz N, Kreidenweis U, Rodrigues R, Popov R, Humpenoeder F, Giannousakis A, Levesque A, Klein D, Araujo E, Bleidorn E, Beier F, Oeser J, Pehl M, Leip D, Crawford M, Molina Bacca E, von Jeetze P, Martinelli E, Schreyer F, Soergel B, Sauer P, Hötten D, Hasse R, Abrahão G, Weigmann P, Dietrich J (2025). "mrcommons: MadRat commons Input Data Library." doi:10.5281/zenodo.3822009 <https://doi.org/10.5281/zenodo.3822009>, Version: 1.59.0, <https://github.com/pik-piam/mrcommons>.
+Bodirsky B, Karstens K, Baumstark L, Weindl I, Wang X, Mishra A, Wirth S, Stevanovic M, Steinmetz N, Kreidenweis U, Rodrigues R, Popov R, Humpenoeder F, Giannousakis A, Levesque A, Klein D, Araujo E, Bleidorn E, Beier F, Oeser J, Pehl M, Leip D, Crawford M, Molina Bacca E, von Jeetze P, Martinelli E, Schreyer F, Soergel B, Sauer P, Hötten D, Hasse R, Abrahão G, Weigmann P, Dietrich J (2025). "mrcommons: MadRat commons Input Data Library." doi:10.5281/zenodo.3822009 <https://doi.org/10.5281/zenodo.3822009>, Version: 1.59.1, <https://github.com/pik-piam/mrcommons>.
 
 A BibTeX entry for LaTeX users is
 
@@ -49,9 +49,9 @@ A BibTeX entry for LaTeX users is
   title = {mrcommons: MadRat commons Input Data Library},
   author = {Benjamin Leon Bodirsky and Kristine Karstens and Lavinia Baumstark and Isabelle Weindl and Xiaoxi Wang and Abhijeet Mishra and Stephen Wirth and Mishko Stevanovic and Nele Steinmetz and Ulrich Kreidenweis and Renato Rodrigues and Roman Popov and Florian Humpenoeder and Anastasis Giannousakis and Antoine Levesque and David Klein and Ewerton Araujo and Eva Bleidorn and Felicitas Beier and Julian Oeser and Michaja Pehl and Debbora Leip and Michael Crawford and Edna {Molina Bacca} and Patrick {von Jeetze} and Eleonora Martinelli and Felix Schreyer and Bjoern Soergel and Pascal Sauer and David Hötten and Robin Hasse and Gabriel Abrahão and Pascal Weigmann and Jan Philipp Dietrich},
   doi = {10.5281/zenodo.3822009},
-  date = {2025-07-30},
+  date = {2025-08-07},
   year = {2025},
   url = {https://github.com/pik-piam/mrcommons},
-  note = {Version: 1.59.0},
+  note = {Version: 1.59.1},
 }
 ```


### PR DESCRIPTION
Removing "1A3aii_Domestic-aviation" from the variables that are spread to countries and then re-aggregated because it actually has country-level data. No changed to mrremind necessary.

Should solve the ``Aircraft`` issue here: https://github.com/remindmodel/development_issues/issues/633#issuecomment-3155138248